### PR TITLE
Fixed documentation for color procedure

### DIFF
--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1123,10 +1123,10 @@ export const image: Doc = new Doc(
 )
 
 export const color: Doc = new Doc(
-  '(color r b g a): string?', [
+  '(color r g b a): string?', [
     'r: integer?, 0 <= r <= 255',
-    'b: integer?, 0 <= b <= 255',
     'g: integer?, 0 <= g <= 255',
+    'b: integer?, 0 <= b <= 255',
     'a: integer?, 0 <= a <= 1'
   ],
   'Returns a string of the form `"rgba(r, g, b, a)"` appropriate for use as a color.'


### PR DESCRIPTION
In the documentation of the `color` procedure, the `g` and `b` parameter positions were switched compared to the correct positions. This change will fix the documentation error.